### PR TITLE
docs: correct repo path in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Before you begin, ensure you have:
 1. **Clone and Install**
    ```bash
    git clone <repository-url>
-   cd training-platform
+   cd trainpro-platform
    npm install
    ```
 


### PR DESCRIPTION
## Summary
- fix Quick Start instructions to use correct repository name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a12ed05bf88323ab4cb90b51db9ccb